### PR TITLE
Update POM for Swagger UI enabling

### DIFF
--- a/pre-registration/pom.xml
+++ b/pre-registration/pom.xml
@@ -73,6 +73,9 @@
 
 		<!-- Swagger -->
 		<swagger.version>2.9.2</swagger.version>
+		<swagger.core.version>2.0.7</swagger.core.version>
+		<swagger.annotations.version>1.5.21</swagger.annotations.version>
+		<springfox.version>2.9.2</springfox.version>
 
 		<!-- Data Access -->
 		<eclipselink.version>2.5.0</eclipselink.version>


### PR DESCRIPTION
As part threat modelling, it is required that we have to enable Swagger UI, making the necessary changes. This file needs to be updated for Maven properties to be used by child projects.